### PR TITLE
Task 036 - JUnit Tests set up - Restaurant Listing service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,17 @@
 					</excludes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.10</version>
+				<configuration>
+					<excludes>
+						<exclude>**/dto/**</exclude>
+						<exclude>**/entity/**</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/test/java/com/project/tejas/restaurantlisting/RestaurantlistingApplicationTests.java
+++ b/src/test/java/com/project/tejas/restaurantlisting/RestaurantlistingApplicationTests.java
@@ -5,9 +5,4 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class RestaurantlistingApplicationTests {
-
-	@Test
-	void contextLoads() {
-	}
-
 }

--- a/src/test/java/com/project/tejas/restaurantlisting/controller/RestaurantListingControllerTest.java
+++ b/src/test/java/com/project/tejas/restaurantlisting/controller/RestaurantListingControllerTest.java
@@ -1,0 +1,71 @@
+package com.project.tejas.restaurantlisting.controller;
+
+import com.project.tejas.restaurantlisting.dto.RestaurantListingDTO;
+import com.project.tejas.restaurantlisting.service.RestaurantListingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class RestaurantListingControllerTest {
+
+    @InjectMocks
+    RestaurantListingController restaurantListingController;
+
+    @Mock
+    RestaurantListingService restaurantListingService;
+
+    @BeforeEach
+    public void setUp(){
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testFetchAllRestaurants(){
+        List<RestaurantListingDTO> mockRestaurants = Arrays.asList(
+                new RestaurantListingDTO(1, "Restaurant 1", "Address 1", "city 1","Description 1"),
+                new RestaurantListingDTO(2, "Restaurant 2", "Address 2", "city 2", "Description 2")
+        );
+        when(restaurantListingService.findAllRestaurants()).thenReturn(mockRestaurants);
+
+        ResponseEntity<List<RestaurantListingDTO>> response = restaurantListingController.fetchAllRestaurants();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(mockRestaurants, response.getBody());
+        verify(restaurantListingService, times(1)).findAllRestaurants();
+    }
+
+    @Test
+    public void testSaveRestaurant(){
+        RestaurantListingDTO mockAddedRestaurant = new RestaurantListingDTO(1, "Restaurant 1", "Address 1", "city 1", "Description 1");
+        when(restaurantListingService.addRestaurantToDb(mockAddedRestaurant)).thenReturn(mockAddedRestaurant);
+
+        ResponseEntity<RestaurantListingDTO> response = restaurantListingController.saveRestaurant(mockAddedRestaurant);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals(mockAddedRestaurant, response.getBody());
+        verify(restaurantListingService, times(1)).addRestaurantToDb(mockAddedRestaurant);
+    }
+
+    @Test
+    public void testFetchRestaurant(){
+        Integer mockId = 1;
+        RestaurantListingDTO mockRestaurant = new RestaurantListingDTO(1, "Restaurant 1", "Address 1", "city 1", "Description 1");
+        when(restaurantListingService.findRestaurantById(mockId)).thenReturn(new ResponseEntity<>(mockRestaurant, HttpStatus.OK));
+
+        ResponseEntity<RestaurantListingDTO> response = restaurantListingController.fetchRestaurant(mockId);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(mockRestaurant, response.getBody());
+        verify(restaurantListingService, times(1)).findRestaurantById(mockId);
+    }
+}

--- a/src/test/java/com/project/tejas/restaurantlisting/service/RestaurantListingServiceTest.java
+++ b/src/test/java/com/project/tejas/restaurantlisting/service/RestaurantListingServiceTest.java
@@ -1,0 +1,95 @@
+package com.project.tejas.restaurantlisting.service;
+
+import com.project.tejas.restaurantlisting.dto.RestaurantListingDTO;
+import com.project.tejas.restaurantlisting.entity.RestaurantListing;
+import com.project.tejas.restaurantlisting.mapper.RestaurantListingMapper;
+import com.project.tejas.restaurantlisting.repo.RestaurantListingRepo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class RestaurantListingServiceTest {
+
+    @Mock
+    RestaurantListingRepo restaurantListingRepo;
+
+    @InjectMocks
+    RestaurantListingService restaurantListingService;
+
+    @BeforeEach
+    public void setUp(){
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testFindAllRestaurants(){
+        List<RestaurantListing> mockRestaurantList = Arrays.asList(
+                new RestaurantListing(1, "Restaurant 1", "Address 1", "city 1", "Description 1"),
+                new RestaurantListing(2, "Restaurant 2", "Address 2", "city 2", "Description 2")
+        );
+        when(restaurantListingRepo.findAll()).thenReturn(mockRestaurantList);
+
+        List<RestaurantListingDTO> restaurantListingDTOList = restaurantListingService.findAllRestaurants();
+
+        assertEquals(mockRestaurantList.size(), restaurantListingDTOList.size());
+        for (int i = 0; i < mockRestaurantList.size(); i++){
+            RestaurantListingDTO expectedDTO = RestaurantListingMapper.INSTANCE.mapRestauranttoRestaurantDTO(mockRestaurantList.get(i));
+            assertEquals(expectedDTO, restaurantListingDTOList.get(i));
+        }
+
+        verify(restaurantListingRepo, times(1)).findAll();
+    }
+
+    @Test
+    public void testAddRestaurantToDb(){
+        RestaurantListingDTO mockAddedRestaurantDTO = new RestaurantListingDTO(1, "Restaurant 1", "Address 1", "city 1", "Description 1");
+        RestaurantListing mockAddedRestaurant = RestaurantListingMapper.INSTANCE.mapRestaurantDTOtoRestaurant(mockAddedRestaurantDTO);
+
+        //Just mock the repository's behavior: Takes an entity, then returns an entity
+        when(restaurantListingRepo.save(mockAddedRestaurant)).thenReturn(mockAddedRestaurant);
+
+        RestaurantListingDTO savedRestaurantDTO = restaurantListingService.addRestaurantToDb(mockAddedRestaurantDTO);
+
+        assertEquals(mockAddedRestaurantDTO, savedRestaurantDTO);
+
+        verify(restaurantListingRepo, times(1)).save(mockAddedRestaurant);
+
+    }
+
+    @Test
+    public void testFindRestaurantById(){
+        Integer mockId = 1;
+        RestaurantListing mockRestaurant = new RestaurantListing(1, "Restaurant 1", "Address 1", "city 1", "Description 1");
+        when(restaurantListingRepo.findById(mockId)).thenReturn(Optional.of(mockRestaurant));
+
+        ResponseEntity<RestaurantListingDTO> response = restaurantListingService.findRestaurantById(mockId);
+
+        assertEquals(mockId, response.getBody().getId());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(restaurantListingRepo, times(1)).findById(mockId);
+    }
+
+    @Test
+    public void testFindRestaurantById_NonExistingID(){
+        Integer mockId = 1;
+        RestaurantListing mockRestaurant = new RestaurantListing(1, "Restaurant 1", "Address 1", "city 1", "Description 1");
+        when(restaurantListingRepo.findById(mockId)).thenReturn(Optional.empty());
+
+        ResponseEntity<RestaurantListingDTO> response = restaurantListingService.findRestaurantById(mockId);
+
+        assertEquals(null, response.getBody());
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        verify(restaurantListingRepo, times(1)).findById(mockId);
+    }
+}


### PR DESCRIPTION
Task 036 - JUnit Tests set up - Restaurant Listing service

Description: Set up Test files with their JUnit test cases for Controller and Service classes. Also added exclusions for DTO and Entity in the pom files as they are boiler plate code, and hence should not be counted for test coverage. Achieved 80% coverage with this.

Files changed:
RestaurantListingControllerTest.java (created)
RestaurantListingServiceTest.java (created)
RestaurantListingApplicationTest.java
pom.xml