### PR TITLE
Defect 006 - Coverage doesn’t return a valid response

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,10 @@ pipeline {
                     def coverage = sh(
                         script: "echo ${response} | jq -r '.component.measures[0].value'",
                         returnStdout: true
-                    ).trim().toDouble()
+                    ).trim()
+
+                    echo "Raw jq output: '${coverageRaw}'"
+                    def coverageRaw = coverage ? coverage.toDouble() : 0.0
 
                     echo: "Coverage: ${coverage}"
 


### PR DESCRIPTION
Jenkins fails with an empty string error while trying to convert the coverage value to a double type.
Files changed:
Jenkinsfile