### PR TITLE
Defect 006 - Coverage doesn’t return a valid response - fixing Groovy parsing issue

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,12 +52,9 @@ pipeline {
                     ).trim()
 
                     def coverage = sh(
-                        script: "echo ${response} | jq -r '.component.measures[0].value'",
+                        script: "echo $\"{response}\" | jq -r '.component.measures[0].value'",
                         returnStdout: true
-                    ).trim()
-
-                    echo "Raw jq output: '${coverage}'"
-                    def coverageRaw = coverage ? coverage.toDouble() : 0.0
+                    ).trim().toDouble()
 
                     echo: "Coverage: ${coverage}"
 


### PR DESCRIPTION
Defect 006 - Coverage doesn’t return a valid response - fixing Groovy parsing issue

This might be happening because Groovy is not parsing the $response properly. Using double quotes lets the shell see the JSON stored in that variable instead of the literal string $response.